### PR TITLE
chore: add repo governance and community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @msutara

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a problem with the upgrade tool
+title: "[Bug] "
+labels: bug
+assignees: msutara
+---
+
+## Describe the bug
+
+<!-- A clear description of what went wrong -->
+
+## Environment
+
+- **Starting Debian version**: <!-- e.g., Jessie (8), Stretch (9) -->
+- **Current upgrade stage**: <!-- e.g., jessie, stretch, buster, bullseye, finalize (empty when complete) -->
+- **How you checked**: `sudo bash ~/UCK/bin/uck-upgrade --status`
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? -->
+
+## Logs
+
+<!-- Paste relevant output from /var/log/uck-upgrade.log -->
+
+```text
+(paste logs here)
+```
+
+## Additional context
+
+<!-- Any other information (screenshots, hardware modifications, etc.) -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an improvement or new feature
+title: "[Feature] "
+labels: enhancement
+assignees: msutara
+---
+
+## Problem
+
+<!-- What problem does this solve? What's missing or inconvenient? -->
+
+## Proposed solution
+
+<!-- How should it work? -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought about? -->
+
+## Additional context
+
+<!-- Hardware setup, use case details, related issues, etc. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Description
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Changes
+
+<!-- List the key changes made -->
+
+-
+
+## Testing
+
+<!-- How was this tested? -->
+
+- [ ] ShellCheck passes (see CONTRIBUTING.md for the full command)
+- [ ] Dry-run smoke test passes (`sudo bash tests/dry-run-smoke.sh`)
+- [ ] Tested with `--dry-run` on target hardware (if applicable)
+
+## Documentation
+
+- [ ] Updated relevant docs (README, USAGE, HOW-IT-WORKS, TROUBLESHOOTING)
+- [ ] Updated `.github/copilot-instructions.md` (if architecture changed)
+- [ ] No documentation changes needed
+
+## Checklist
+
+- [ ] Changes are minimal and focused on a single concern
+- [ ] No secrets or credentials committed
+- [ ] Line endings are LF (not CRLF)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior should be
+reported by contacting the maintainer directly at the email listed on their
+[GitHub profile](https://github.com/msutara). Do not include sensitive personal
+information in public GitHub issues.
+
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to uck-gen1
+
+Thanks for your interest in improving the UCK Gen1 upgrade tool! This document
+explains how to contribute effectively.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork
+3. Create a feature branch from `main`
+
+```bash
+git checkout -b feat/my-change main
+```
+
+## Development Guidelines
+
+### Shell scripting conventions
+
+- All scripts must pass `shellcheck --severity=warning`
+- Use `[[ ]]` for conditionals (not `[ ]`)
+- Use `$()` for command substitution (not backticks)
+- All awk patterns must use `[ \t]` (not `[[:space:]]`) for mawk
+  compatibility on Jessie
+- Use `[[:blank:]]` in grep regexes for POSIX portability
+- All destructive commands must go through the `run` wrapper so `--dry-run`
+  works
+- Non-critical commands use `run_optional` (allows failure without aborting)
+
+### Line endings
+
+The repository enforces LF line endings via `.gitattributes`. If you're on
+Windows, ensure `core.autocrlf` is set to `true` or `input`.
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```txt
+feat: add new feature
+fix: correct bug in stretch stage
+docs: update troubleshooting guide
+chore: update CI workflow
+```
+
+## Testing
+
+### ShellCheck
+
+```bash
+find . -type f \( -name '*.sh' -o -name 'uck-upgrade' \) -print0 \
+  | xargs -0 shellcheck --severity=warning
+```
+
+### Dry-run smoke test
+
+```bash
+sudo bash tests/dry-run-smoke.sh
+```
+
+### Dry-run mode
+
+Preview what the tool would do without making changes:
+
+```bash
+sudo bash ~/UCK/bin/uck-upgrade --dry-run
+```
+
+## Pull Request Process
+
+1. Ensure shellcheck passes with zero warnings
+2. Ensure the dry-run smoke test passes
+3. Update documentation if your change affects user-facing behavior
+4. Fill out the PR template completely
+5. Wait for CI to pass and maintainer review
+
+## Hardware Notes
+
+- **Target hardware**: Ubiquiti UniFi Cloud Key Gen1 only
+- **Root filesystem**: AUFS overlay — `mv` on top-level dirs returns EBUSY
+- **Final target**: Bullseye (Debian 11) — Bookworm is
+  [incompatible](docs/BOOKWORM-FINDINGS.md)
+- **Oldest environment**: Jessie (Debian 8) with mawk — ensure backward
+  compatibility
+
+## Code of Conduct
+
+This project follows the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating,
+you agree to abide by its terms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| main    | ✅ Yes    |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly.
+
+**Do NOT file a public issue.** Instead, use one of these methods:
+
+1. **GitHub private vulnerability reporting** — go to the
+   [Security tab](https://github.com/msutara/uck-gen1/security/advisories/new)
+   and click "Report a vulnerability"
+2. **Email** — contact the maintainer directly at the email listed on their
+   [GitHub profile](https://github.com/msutara)
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected files or components
+- Potential impact (e.g., privilege escalation, data loss)
+
+### Response timeline
+
+- **Acknowledgement**: within 48 hours
+- **Initial assessment**: within 1 week
+- **Fix or mitigation**: best effort, typically within 2 weeks
+
+## Scope
+
+This tool runs as **root** on embedded hardware and modifies system packages,
+`/etc/apt/sources.list`, `/etc/rc.local`, and SSH configuration. Security
+issues in any of these areas are in scope.
+
+Out of scope:
+
+- Vulnerabilities in upstream Debian packages
+- Issues specific to UniFi firmware (report to Ubiquiti)


### PR DESCRIPTION
Add standard public repository governance files to improve contributor experience and security posture.

## Files Added

| File | Purpose |
|------|---------|
| **SECURITY.md** | Vulnerability reporting policy — directs reporters to private channels |
| **CONTRIBUTING.md** | Development guidelines, shell conventions, testing, PR process |
| **CODE_OF_CONDUCT.md** | Contributor Covenant v2.1 |
| **.github/CODEOWNERS** | Auto-assigns maintainer to all PRs |
| **.github/pull_request_template.md** | PR checklist (tests, docs, line endings) |
| **.github/ISSUE_TEMPLATE/bug_report.md** | Structured bug reports (environment, logs, steps) |
| **.github/ISSUE_TEMPLATE/feature_request.md** | Feature request template |
| **.github/dependabot.yml** | Weekly GitHub Actions dependency updates |

## Manual Step Required

After merge, enable branch protection on \main\ via **Settings → Rules → Rulesets**:
- Require PR reviews before merge
- Require status checks: \shellcheck\, \dry-run-smoke\
- Block force-push and deletion

## Testing

- No code changes — docs/config only
- CI (shellcheck + dry-run smoke) should pass unchanged