### PR TITLE
fix: add apt-get clean after each upgrade stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ sudo bash ~/UCK/bin/uck-upgrade --status
 - [How It Works](docs/HOW-IT-WORKS.md) — architecture and state machine design
 - [Troubleshooting](docs/TROUBLESHOOTING.md) — common issues and recovery steps
 - [Bookworm Findings](docs/BOOKWORM-FINDINGS.md) — why Bookworm is not supported
+- [Contributing](CONTRIBUTING.md) — development guidelines and PR process
+- [Security Policy](SECURITY.md) — vulnerability reporting
 
 ## ⚠️ Warning
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -98,6 +98,45 @@ Bookworm (Debian 12) is incompatible with UCK Gen1 hardware. Bullseye
 (Debian 11) is the final supported target. See
 [BOOKWORM-FINDINGS.md](BOOKWORM-FINDINGS.md) for details.
 
+## Low Disk Space During Upgrade
+
+The UCK Gen1 has limited internal storage. Each `dist-upgrade` downloads
+hundreds of megabytes of packages to `/var/cache/apt/archives/`. The upgrade
+tool automatically runs `apt-get clean` after every stage to purge the
+download cache and reclaim space.
+
+If the device still runs out of space mid-upgrade:
+
+1. Clear the APT cache manually:
+
+   ```bash
+   sudo apt-get clean
+   ```
+
+2. Remove old logs if they are large:
+
+   ```bash
+   sudo truncate -s 0 /var/log/uck-upgrade.log
+   sudo journalctl --vacuum-size=10M
+   ```
+
+3. Check what is consuming space:
+
+   ```bash
+   du -sh /var/cache/apt /var/log /var/lib/dpkg /srv
+   ```
+
+4. As a last resort, temporarily relocate the APT cache to `/srv` (which
+   may be on a larger partition on some UCK models):
+
+   ```bash
+   sudo mv /var/cache/apt /srv/apt-cache
+   sudo ln -s /srv/apt-cache /var/cache/apt
+   ```
+
+   **Warning**: This is device-specific and should be reversed after the
+   upgrade completes.
+
 ## Manual Recovery
 
 If the automated upgrade fails partway through, you can manually advance to the next stage:

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -87,6 +87,8 @@ apt_upgrade() {
     run_optional apt-get -qy -o "Dpkg::Options::=--force-confnew" --fix-broken install
     run apt-get -qy -o "Dpkg::Options::=--force-confnew" upgrade
     run apt-get -qy -o "Dpkg::Options::=--force-confnew" dist-upgrade
+    # Free disk space by purging the APT download cache after each stage.
+    run_optional apt-get -qy clean
 }
 
 apt_cleanup() {

--- a/tests/dry-run-smoke.sh
+++ b/tests/dry-run-smoke.sh
@@ -109,6 +109,7 @@ assert_contains "State transitions"       "DRY-RUN.*Would replace trailing state
 assert_contains "Reboot simulation"       "DRY-RUN.*Would reboot now"
 assert_contains "apt-get upgrade"         "DRY-RUN.*Would run.*apt-get.*[^-]upgrade"
 assert_contains "apt-get dist-upgrade"    "DRY-RUN.*Would run.*dist-upgrade"
+assert_contains "apt-get clean"           "DRY-RUN.*Would run.*optional.*apt-get -qy clean"
 assert_contains "Jessie bootstrap"        "DRY-RUN.*Bootstrapping initial state.*jessie"
 assert_contains "rc.local hook"           "DRY-RUN.*Would ensure marker"
 


### PR DESCRIPTION
## Problem

The UCK Gen1 has limited internal storage. Each dist-upgrade downloads hundreds of megabytes of packages to /var/cache/apt/archives/. Without clearing this cache between stages, the device can run out of space mid-upgrade.

## Changes

### Code
- Add apt-get clean at the end of apt_upgrade() to purge the download cache after every stage

### Documentation
- Add Contributing and Security Policy links to README Documentation section
- Add Low Disk Space During Upgrade section to Troubleshooting with manual recovery steps

### Tests
- Add smoke test assertion verifying apt-get clean appears in dry-run output

## Testing

- [x] ShellCheck passes
- [x] Dry-run smoke test passes
